### PR TITLE
unknown token

### DIFF
--- a/src/PHPDeviceChecker.php
+++ b/src/PHPDeviceChecker.php
@@ -74,13 +74,12 @@ class PHPDeviceChecker
      */
     private function getOs()
     {
-        if (preg_match('/[_\-]/', $this->token))
-        {
+        if (preg_match('/[_\-]/', $this->token)) {
             $this->result[$this->token]=array("isiOs"=>false,"isAndroid"=>true,"os"=>"android");
-        }
-        else {
+        } elseif (mb_strlen($this->token) == 64) {
             $this->result[$this->token]=array("isiOs"=>true,"isAndroid"=>false,"os"=>"ios");
-
+        } else {
+            return $this->result[$this->token]=array("isiOs"=>false,"isAndroid"=>false,"os"=>"");
         }
     }
 }

--- a/test/PHPDeviceCheckerTest.php
+++ b/test/PHPDeviceCheckerTest.php
@@ -4,6 +4,7 @@ class PHPDeviceCheckerTest extends PHPUnit_Framework_TestCase
 {
     protected $iOsToken="7a20e06257a5d5c608cad848df5f351e6693ffce8aa04cc7bb290bca915a4f17";
     protected $androidToken="APA91bFiQLPpECz3fRRgrYZIsZJah9t20YRgITmu7nWaa4M2k115E83oZeGqzIx8_YKXYot--x_rVcV-JQG-9w1GsR2aQQJPbNYkH-mqJf15T10Ewy1pLXLnwcex0W5pJ6Bk-ubKlz9vXkyUu8eo_q_lp4um_IesCAPntEnagMfjP9dBDIP1sRw";
+
     public function testClassExists()
     {
         $this->assertTrue(class_exists('\PHPDeviceChecker\PHPDeviceChecker'));
@@ -48,5 +49,12 @@ class PHPDeviceCheckerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('ios',$testArray->os());
         $this->assertEquals('ios',$testArray->os($this->iOsToken));
         $this->assertEquals('android',$testArray->os($this->androidToken));
+    }
+
+    public function testIfUnknownTokenNeedToReturnEmptyArray()
+    {
+        $testArray = new \PHPDeviceChecker\PHPDeviceChecker(md5(time()));
+        $this->assertFalse($testArray->isiOs());
+        $this->assertFalse($testArray->isAndroid());
     }
 }


### PR DESCRIPTION
If checker will get any string as a token and this token do not match android regexp, then it will be automatically recognised as iOS token. 

iOS token has strict defined length, so we can check it... 
